### PR TITLE
feat(redis): clean expired redis keys

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -10,14 +10,14 @@ RUN apt-get update && \
 # Copy pom.xml
 COPY pom.xml ./
 
-# Download dependencies
-RUN mvn dependency:go-offline
+# Download dependencies and plugins
+RUN mvn dependency:go-offline -B
 
 # Copy the source code
 COPY src ./src
 
 # Build the application
-RUN mvn package -DskipTests
+RUN mvn clean package -DskipTests -B
 
 # Expose the application port
 EXPOSE 8080

--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,14 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>3.2.3</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/com/securevault/main/MainApplication.java
+++ b/src/main/java/com/securevault/main/MainApplication.java
@@ -5,13 +5,19 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.core.SpringVersion;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 @SpringBootApplication(exclude = { SecurityAutoConfiguration.class })
 @EnableMongoRepositories("com.securevault.main.repository")
+@EnableScheduling
 public class MainApplication {
 
 	public static void main(String[] args) {
 		System.out.println("Spring Version: " + SpringVersion.getVersion());
+		log.info("🚀 Starting Secure Vault application...");
 		SpringApplication.run(MainApplication.class, args);
 	}
 

--- a/src/main/java/com/securevault/main/service/expiration/RedisCleanupScheduler.java
+++ b/src/main/java/com/securevault/main/service/expiration/RedisCleanupScheduler.java
@@ -1,0 +1,92 @@
+package com.securevault.main.service.expiration;
+
+import jakarta.annotation.PostConstruct;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Scheduled task for cleaning up Redis indexed fields.
+ * Runs every 10 minutes by default and can be configured via properties.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisCleanupScheduler {
+
+    private final RedisCleanupService redisCleanupService;
+    private final RedisEntityDiscoveryService redisEntityDiscoveryService;
+
+    @Value("${app.redis.cleanup.enabled:true}")
+    private boolean cleanupEnabled;
+
+    @Value("${app.redis.cleanup.interval:600000}") // 10 minutes in milliseconds
+    private long cleanupInterval;
+
+    /**
+     * Initialize and log scheduler configuration
+     */
+    @PostConstruct
+    public void initialize() {
+        log.info("Redis Cleanup Scheduler initialized - Enabled: {}, Interval: {}ms ({} seconds)",
+                cleanupEnabled, cleanupInterval, cleanupInterval / 1000);
+
+        if (cleanupEnabled) {
+            log.info("Scheduled Redis cleanup will run every {} seconds", cleanupInterval / 1000);
+        } else {
+            log.warn("Redis cleanup is DISABLED. No automatic cleanup will occur.");
+        }
+    }
+
+    /**
+     * Scheduled task to perform Redis index cleanup.
+     * Runs every 10 minutes by default, configurable via app.redis.cleanup.interval
+     */
+    @Scheduled(fixedRateString = "${app.redis.cleanup.interval:600000}")
+    public void scheduledCleanup() {
+        log.debug("Scheduled cleanup triggered. Enabled: {}, Interval: {}ms", cleanupEnabled, cleanupInterval);
+
+        if (!cleanupEnabled) {
+            log.debug("Redis cleanup is disabled. Skipping scheduled cleanup.");
+            return;
+        }
+
+        try {
+            log.info("Starting scheduled Redis cleanup...");
+
+            long startTime = System.currentTimeMillis();
+
+            // Perform the cleanup
+            RedisCleanupService.CleanupResult result = redisCleanupService.performCleanup();
+
+            long duration = System.currentTimeMillis() - startTime;
+
+            // Log the results
+            if (result.getErrors() > 0) {
+                log.warn(
+                        "Scheduled cleanup completed with {} errors. Processed {} entities, cleaned {} entries in {}ms",
+                        result.getErrors(), result.getEntitiesProcessed(), result.getIndexEntriesCleaned(), duration);
+            } else if (result.getIndexEntriesCleaned() > 0) {
+                log.info("Scheduled cleanup completed successfully. Processed {} entities, cleaned {} entries in {}ms",
+                        result.getEntitiesProcessed(), result.getIndexEntriesCleaned(), duration);
+            } else {
+                log.debug("Scheduled cleanup completed. No stale data found to clean up. Duration: {}ms", duration);
+            }
+
+        } catch (Exception e) {
+            log.error("Error during scheduled Redis cleanup", e);
+        }
+    }
+
+    /**
+     * Clear the entity discovery cache (useful for testing or re-discovery)
+     */
+    public void clearDiscoveryCache() {
+        redisEntityDiscoveryService.clearCache();
+    }
+
+}

--- a/src/main/java/com/securevault/main/service/expiration/RedisCleanupService.java
+++ b/src/main/java/com/securevault/main/service/expiration/RedisCleanupService.java
@@ -1,0 +1,375 @@
+package com.securevault.main.service.expiration;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Redis cleanup service that removes stale indexed data when entities with TTL
+ * expire.
+ * This service uses the RedisEntityDiscoveryService to find entities that need
+ * cleanup
+ * and performs the actual cleanup operations.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RedisCleanupService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final RedisEntityDiscoveryService redisEntityDiscoveryService;
+
+    /**
+     * Perform cleanup of stale Redis indexed data
+     * This method uses the discovery service to find entities and cleans up expired
+     * indexed fields
+     */
+    public CleanupResult performCleanup() {
+        CleanupResult result = new CleanupResult();
+
+        try {
+            log.debug("Starting Redis cleanup...");
+
+            // Discover all Redis entities using the dedicated discovery service
+            redisEntityDiscoveryService.discoverRedisEntities();
+
+            // Get entities that need cleanup
+            Map<Class<?>, RedisEntityDiscoveryService.EntityMetadata> entitiesToClean = redisEntityDiscoveryService
+                    .getEntitiesNeedingCleanup();
+
+            // Clean up each entity that needs cleanup
+            for (Map.Entry<Class<?>, RedisEntityDiscoveryService.EntityMetadata> entry : entitiesToClean.entrySet()) {
+                Class<?> entityClass = entry.getKey();
+                RedisEntityDiscoveryService.EntityMetadata metadata = entry.getValue();
+
+                try {
+                    int cleaned = cleanupEntity(entityClass, metadata);
+                    if (cleaned > 0) {
+                        result.incrementEntitiesProcessed();
+                        result.addCleanedEntries(cleaned);
+                        log.debug("Cleaned {} stale index entries for entity: {}",
+                                cleaned, entityClass.getSimpleName());
+                    }
+                } catch (Exception e) {
+                    log.error("Error cleaning up entity: {}", entityClass.getSimpleName(), e);
+                    result.incrementErrors();
+                }
+            }
+
+            log.debug("Redis cleanup completed. Processed {} entities, cleaned {} entries",
+                    result.getEntitiesProcessed(), result.getIndexEntriesCleaned());
+
+        } catch (Exception e) {
+            log.error("Error during Redis cleanup", e);
+            result.incrementErrors();
+        }
+
+        return result;
+    }
+
+    /**
+     * Clean up a specific entity type
+     * 
+     * @param entityClass The entity class
+     * @param metadata    Entity metadata
+     * @return Number of cleaned index entries
+     */
+    private int cleanupEntity(Class<?> entityClass, RedisEntityDiscoveryService.EntityMetadata metadata) {
+        try {
+            int totalCleaned = 0;
+            String hashName = metadata.getHashName();
+
+            // Clean up stale entity hashes and update main set
+            totalCleaned += cleanupStaleEntityHashes(hashName);
+            
+            // Also clean up any orphaned entity hashes that aren't in the main set
+            // totalCleaned += cleanupOrphanedEntityHashes(hashName);
+            
+            // Clean up indexed fields
+            for (String fieldName : metadata.getIndexedFieldNames()) {
+                try {
+                    int cleaned = cleanupIndexedField(hashName, fieldName);
+                    totalCleaned += cleaned;
+                } catch (Exception e) {
+                    log.warn("Error cleaning up indexed field: {}", fieldName, e);
+                }
+            }
+
+            return totalCleaned;
+
+        } catch (Exception e) {
+            log.error("Error cleaning up entity: {}", entityClass.getSimpleName(), e);
+            return 0;
+        }
+    }
+
+    /**
+     * Clean up stale entity hashes and remove their IDs from the main set
+     * 
+     * @param hashName The hash name (e.g., "jwt_tokens")
+     * @return Number of cleaned entries
+     */
+    private int cleanupStaleEntityHashes(String hashName) {
+        int totalCleaned = 0;
+
+        try {
+            // Get connection factory
+            var connectionFactory = redisTemplate.getConnectionFactory();
+            if (connectionFactory == null) {
+                log.warn("Redis connection factory is null, skipping entity hash cleanup");
+                return 0;
+            }
+
+            // Get all entity IDs from the main set
+            Set<byte[]> entityIdBytes = connectionFactory
+                    .getConnection()
+                    .setCommands()
+                    .sMembers(hashName.getBytes());
+
+            if (entityIdBytes == null || entityIdBytes.isEmpty()) {
+                return 0;
+            }
+
+            // Check each entity ID to see if the corresponding entity hash is expired
+            for (byte[] entityIdByteArray : entityIdBytes) {
+                String entityId = new String(entityIdByteArray);
+                String entityHashKey = hashName + ":" + entityId + ":idx";
+
+                // Check if the entity hash key exists and get its TTL
+                Boolean exists = redisTemplate.hasKey(entityHashKey);
+                Long ttl = redisTemplate.getExpire(entityHashKey);
+
+                log.debug("Entity hash key: {}, exists: {}, ttl: {}", entityHashKey, exists, ttl);
+
+                // If the key doesn't exist or has expired TTL, clean it up
+                if (exists != null && !exists) {
+                    // Remove the entity hash if it still exists but is expired
+                    // if (exists != null && exists) {
+                    redisTemplate.delete(entityHashKey);
+                    // }
+
+                    // Remove from main set
+                    Long removed = connectionFactory
+                            .getConnection()
+                            .setCommands()
+                            .sRem(hashName.getBytes(), entityIdByteArray);
+
+                    if (removed != null && removed > 0) {
+                        totalCleaned += removed;
+                    }
+                }
+            }
+
+        } catch (Exception e) {
+            log.warn("Error cleaning up entity hashes: {}", hashName, e);
+        }
+
+        return totalCleaned;
+    }
+
+    /**
+     * Clean up orphaned entity hashes that exist but aren't in the main set
+     * 
+     * @param hashName The hash name (e.g., "jwt_tokens")
+     * @return Number of cleaned entries
+     */
+    private int cleanupOrphanedEntityHashes(String hashName) {
+        int totalCleaned = 0;
+
+        try {
+            // Get all entity hash keys that match the pattern
+            String entityHashPattern = hashName + ":*:idx";
+            Set<String> entityHashKeys = redisTemplate.keys(entityHashPattern);
+
+            if (entityHashKeys == null || entityHashKeys.isEmpty()) {
+                return 0;
+            }
+
+            // Get all entity IDs from the main set
+            var connectionFactory = redisTemplate.getConnectionFactory();
+            if (connectionFactory == null) {
+                log.warn("Redis connection factory is null, skipping orphaned entity hash cleanup");
+                return 0;
+            }
+
+            Set<byte[]> mainSetEntityIds = connectionFactory
+                    .getConnection()
+                    .setCommands()
+                    .sMembers(hashName.getBytes());
+
+            Set<String> validEntityIds = new HashSet<>();
+            if (mainSetEntityIds != null) {
+                for (byte[] entityIdBytes : mainSetEntityIds) {
+                    validEntityIds.add(new String(entityIdBytes));
+                }
+            }
+
+            // Check each entity hash key
+            for (String entityHashKey : entityHashKeys) {
+                try {
+                    // Extract entity ID from the key (e.g., "jwt_tokens:UUID:idx" -> "UUID")
+                    String[] parts = entityHashKey.split(":");
+                    if (parts.length >= 2) {
+                        String entityId = parts[1];
+
+                        // If this entity ID is not in the main set, the hash is orphaned
+                        if (!validEntityIds.contains(entityId)) {
+                            // Check if the hash is expired or has no TTL
+                            Long ttl = redisTemplate.getExpire(entityHashKey);
+                            if (ttl == null || ttl <= 0) {
+                                Boolean deleted = redisTemplate.delete(entityHashKey);
+                                if (deleted != null && deleted) {
+                                    totalCleaned++;
+                                }
+                            }
+                        }
+                    }
+                } catch (Exception e) {
+                    log.warn("Error processing orphaned entity hash: {}", entityHashKey, e);
+                }
+            }
+
+        } catch (Exception e) {
+            log.warn("Error cleaning up orphaned entity hashes: {}", hashName, e);
+        }
+
+        return totalCleaned;
+    }
+
+    /**
+     * Clean up indexed fields by removing stale entity IDs from index sets
+     * 
+     * @param hashName  The hash name (e.g., "jwt_tokens")
+     * @param fieldName The field name (e.g., "userId")
+     * @return Number of cleaned index entries
+     */
+    private int cleanupIndexedField(String hashName, String fieldName) {
+        int totalCleaned = 0;
+        int emptyIndexKeysRemoved = 0;
+
+        try {
+            // Get all index keys for this field (Spring Data Redis pattern: hashName:fieldName:value)
+            String indexKeyPattern = hashName + ":" + fieldName + ":*";
+            Set<String> indexKeys = redisTemplate.keys(indexKeyPattern);
+
+            if (indexKeys == null || indexKeys.isEmpty()) {
+                return 0;
+            }
+
+            // Get connection factory once for this field
+            var connectionFactory = redisTemplate.getConnectionFactory();
+            if (connectionFactory == null) {
+                log.warn("Redis connection factory is null, skipping field: {}", fieldName);
+                return 0;
+            }
+
+            for (String indexKey : indexKeys) {
+                try {
+                    // Get all entity IDs in this index set
+                    Set<byte[]> entityIdBytes = connectionFactory
+                            .getConnection()
+                            .setCommands()
+                            .sMembers(indexKey.getBytes());
+
+                    if (entityIdBytes == null || entityIdBytes.isEmpty()) {
+                        // Index set is already empty, remove the index key
+                        Boolean deleted = redisTemplate.delete(indexKey);
+                        if (deleted != null && deleted) {
+                            emptyIndexKeysRemoved++;
+                        }
+                        continue;
+                    }
+
+                    // Check each entity ID to see if the corresponding entity hash still exists
+                    for (byte[] entityIdByteArray : entityIdBytes) {
+                        String entityId = new String(entityIdByteArray);
+                        String entityHashKey = hashName + ":" + entityId;
+
+                        // Check if the entity hash key exists
+                        Boolean exists = redisTemplate.hasKey(entityHashKey);
+
+                        if (exists != null && !exists) {
+                            // Entity hash doesn't exist (expired), remove from index set
+                            Long removed = connectionFactory
+                                    .getConnection()
+                                    .setCommands()
+                                    .sRem(indexKey.getBytes(), entityIdByteArray);
+
+                            if (removed != null && removed > 0) {
+                                totalCleaned += removed;
+                            }
+                        }
+                    }
+
+                    // After cleanup, check if the index set is now empty and remove it if so
+                    Set<byte[]> remainingEntityIds = connectionFactory
+                            .getConnection()
+                            .setCommands()
+                            .sMembers(indexKey.getBytes());
+
+                    if (remainingEntityIds == null || remainingEntityIds.isEmpty()) {
+                        // Index set is now empty after cleanup, remove the index key
+                        Boolean deleted = redisTemplate.delete(indexKey);
+                        if (deleted != null && deleted) {
+                            emptyIndexKeysRemoved++;
+                        }
+                    }
+
+                } catch (Exception e) {
+                    log.warn("Error processing index key: {}", indexKey, e);
+                }
+            }
+
+
+
+        } catch (Exception e) {
+            log.warn("Error cleaning up indexed field: {}", fieldName, e);
+        }
+
+        return totalCleaned;
+    }
+
+    /**
+     * Result class for cleanup operations
+     */
+    public static class CleanupResult {
+        private int entitiesProcessed = 0;
+        private int indexEntriesCleaned = 0;
+        private int errors = 0;
+        private long startTime = System.currentTimeMillis();
+
+        public int getEntitiesProcessed() {
+            return entitiesProcessed;
+        }
+
+        public void incrementEntitiesProcessed() {
+            this.entitiesProcessed += 1;
+        }
+
+        public int getIndexEntriesCleaned() {
+            return indexEntriesCleaned;
+        }
+
+        public void addCleanedEntries(int count) {
+            this.indexEntriesCleaned += count;
+        }
+
+        public int getErrors() {
+            return errors;
+        }
+
+        public void incrementErrors() {
+            this.errors += 1;
+        }
+
+        public long getDurationMs() {
+            return System.currentTimeMillis() - startTime;
+        }
+    }
+}

--- a/src/main/java/com/securevault/main/service/expiration/RedisEntityDiscoveryService.java
+++ b/src/main/java/com/securevault/main/service/expiration/RedisEntityDiscoveryService.java
@@ -1,0 +1,295 @@
+package com.securevault.main.service.expiration;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.HashSet;
+
+import org.springframework.data.redis.core.index.Indexed;
+import org.springframework.data.redis.core.TimeToLive;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.stereotype.Service;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.core.type.classreading.CachingMetadataReaderFactory;
+import org.springframework.core.type.classreading.MetadataReader;
+import org.springframework.core.type.classreading.MetadataReaderFactory;
+import org.springframework.util.ClassUtils;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Service responsible for discovering Redis entities and extracting their
+ * metadata.
+ * This service scans the classpath for classes with @RedisHash annotation
+ * and analyzes their TTL and indexed field configurations.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RedisEntityDiscoveryService {
+
+    // Cache of discovered entity metadata to avoid repeated reflection
+    private final Map<Class<?>, EntityMetadata> entityMetadataCache = new ConcurrentHashMap<>();
+
+    // Package patterns to scan for Redis entities
+    private static final String[] PACKAGE_PATTERNS = {
+            "com.securevault.main.entity"
+    };
+
+    /**
+     * Entity metadata for cleanup operations
+     */
+    public static class EntityMetadata {
+        private final String hashName;
+        private final Set<String> indexedFieldNames;
+        private final boolean hasTtl;
+
+        public EntityMetadata(String hashName, Set<String> indexedFieldNames, boolean hasTtl) {
+            this.hashName = hashName;
+            this.indexedFieldNames = indexedFieldNames;
+            this.hasTtl = hasTtl;
+        }
+
+        public String getHashName() {
+            return hashName;
+        }
+
+        public Set<String> getIndexedFieldNames() {
+            return indexedFieldNames;
+        }
+
+        public boolean hasTtl() {
+            return hasTtl;
+        }
+
+        public boolean needsCleanup() {
+            return hasTtl && !indexedFieldNames.isEmpty();
+        }
+    }
+
+    /**
+     * Discover all Redis entities in the classpath
+     * This method scans for classes with @RedisHash annotation and extracts their
+     * metadata
+     */
+    public void discoverRedisEntities() {
+        try {
+            log.debug("Discovering Redis entities...");
+
+            // Clear previous cache
+            entityMetadataCache.clear();
+
+            int discoveredCount = 0;
+
+            // Scan each package pattern for Redis entities
+            for (String packagePattern : PACKAGE_PATTERNS) {
+                try {
+                    Set<Class<?>> redisEntities = scanPackageForRedisEntities(packagePattern);
+
+                    for (Class<?> entityClass : redisEntities) {
+                        try {
+                            EntityMetadata metadata = extractEntityMetadata(entityClass);
+                            entityMetadataCache.put(entityClass, metadata);
+
+                            if (metadata.needsCleanup()) {
+                                discoveredCount++;
+                                log.info(
+                                        "Discovered Redis entity for cleanup: {} (hash: {}, indexed fields: {}, has TTL: {})",
+                                        entityClass.getSimpleName(),
+                                        metadata.getHashName(),
+                                        metadata.getIndexedFieldNames().size(),
+                                        metadata.hasTtl());
+                            } else {
+                                log.debug("Discovered Redis entity (no cleanup needed): {} (hash: {})",
+                                        entityClass.getSimpleName(), metadata.getHashName());
+                            }
+                        } catch (Exception e) {
+                            log.warn("Error processing Redis entity: {}", entityClass.getName(), e);
+                        }
+                    }
+                } catch (Exception e) {
+                    log.warn("Error scanning package: {}", packagePattern, e);
+                }
+            }
+
+            log.info("Redis entity discovery completed. Found {} entities requiring cleanup.", discoveredCount);
+
+        } catch (Exception e) {
+            log.error("Error during Redis entity discovery", e);
+        }
+    }
+
+    /**
+     * Scan a package for classes with @RedisHash annotation
+     * 
+     * @param packageName The package to scan
+     * @return Set of classes with @RedisHash annotation
+     */
+    private Set<Class<?>> scanPackageForRedisEntities(String packageName) {
+        Set<Class<?>> redisEntities = new HashSet<>();
+
+        try {
+            PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
+            MetadataReaderFactory metadataReaderFactory = new CachingMetadataReaderFactory(resolver);
+
+            String packageSearchPath = "classpath*:" + packageName.replace('.', '/') + "/**/*.class";
+            Resource[] resources = resolver.getResources(packageSearchPath);
+
+            for (Resource resource : resources) {
+                try {
+                    MetadataReader metadataReader = metadataReaderFactory.getMetadataReader(resource);
+                    String className = metadataReader.getClassMetadata().getClassName();
+
+                    // Check if the class has @RedisHash annotation
+                    if (metadataReader.getAnnotationMetadata().hasAnnotation(RedisHash.class.getName())) {
+                        Class<?> clazz = ClassUtils.forName(className, getClass().getClassLoader());
+                        redisEntities.add(clazz);
+                        log.debug("Found Redis entity class: {}", className);
+                    }
+                } catch (Exception e) {
+                    log.debug("Error processing resource: {}", resource.getFilename(), e);
+                }
+            }
+        } catch (Exception e) {
+            log.warn("Error scanning package {} for Redis entities", packageName, e);
+        }
+
+        return redisEntities;
+    }
+
+    /**
+     * Extract metadata from a Redis entity class
+     * 
+     * @param entityClass The entity class to analyze
+     * @return EntityMetadata containing information about the entity
+     */
+    public EntityMetadata extractEntityMetadata(Class<?> entityClass) {
+        Set<String> indexedFields = ConcurrentHashMap.newKeySet();
+        boolean hasTtl = false;
+        String hashName = null;
+
+        // Get hash name from @RedisHash annotation
+        if (entityClass.isAnnotationPresent(RedisHash.class)) {
+            RedisHash redisHash = entityClass.getAnnotation(RedisHash.class);
+            hashName = redisHash.value();
+        }
+
+        log.debug("Processing entity: {}, Hash name: {}", entityClass.getSimpleName(), hashName);
+
+        // Check all fields including inherited ones
+        Class<?> currentClass = entityClass;
+        while (currentClass != null && currentClass != Object.class) {
+            for (Field field : currentClass.getDeclaredFields()) {
+                field.setAccessible(true);
+
+                if (field.isAnnotationPresent(Indexed.class)) {
+                    indexedFields.add(field.getName());
+                }
+
+                if (field.isAnnotationPresent(TimeToLive.class)) {
+                    hasTtl = true;
+                }
+            }
+            currentClass = currentClass.getSuperclass();
+        }
+
+        log.debug("Entity: {}, Indexed fields: {}, Has TTL: {}",
+                entityClass.getSimpleName(), indexedFields, hasTtl);
+
+        return new EntityMetadata(hashName, indexedFields, hasTtl);
+    }
+
+    /**
+     * Get all discovered entity metadata
+     * 
+     * @return Map of entity classes to their metadata
+     */
+    public Map<Class<?>, EntityMetadata> getAllEntityMetadata() {
+        return new HashMap<>(entityMetadataCache);
+    }
+
+    /**
+     * Get discovered entity metadata as a map for REST responses
+     * 
+     * @return Map of entity class names to their metadata
+     */
+    public Map<String, Map<String, Object>> getDiscoveredEntities() {
+        Map<String, Map<String, Object>> result = new HashMap<>();
+
+        for (Map.Entry<Class<?>, EntityMetadata> entry : entityMetadataCache.entrySet()) {
+            Class<?> entityClass = entry.getKey();
+            EntityMetadata metadata = entry.getValue();
+
+            Map<String, Object> entityInfo = new HashMap<>();
+            entityInfo.put("hashName", metadata.getHashName());
+            entityInfo.put("indexedFields", metadata.getIndexedFieldNames());
+            entityInfo.put("hasTtl", metadata.hasTtl());
+            entityInfo.put("needsCleanup", metadata.needsCleanup());
+
+            result.put(entityClass.getSimpleName(), entityInfo);
+        }
+
+        return result;
+    }
+
+    /**
+     * Get entities that need cleanup (have both TTL and indexed fields)
+     * 
+     * @return Map of entity classes to their metadata
+     */
+    public Map<Class<?>, EntityMetadata> getEntitiesNeedingCleanup() {
+        Map<Class<?>, EntityMetadata> result = new HashMap<>();
+
+        for (Map.Entry<Class<?>, EntityMetadata> entry : entityMetadataCache.entrySet()) {
+            if (entry.getValue().needsCleanup()) {
+                result.put(entry.getKey(), entry.getValue());
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Check if a class has TTL and indexed fields
+     * 
+     * @param clazz The class to check
+     * @return true if the class has both TTL and indexed fields
+     */
+    public static boolean hasTtlAndIndexedFields(Class<?> clazz) {
+        boolean hasTtl = false;
+        boolean hasIndexed = false;
+
+        // Check all fields including inherited ones
+        Class<?> currentClass = clazz;
+        while (currentClass != null && currentClass != Object.class) {
+            for (Field field : currentClass.getDeclaredFields()) {
+                if (field.isAnnotationPresent(TimeToLive.class)) {
+                    hasTtl = true;
+                }
+                if (field.isAnnotationPresent(Indexed.class)) {
+                    hasIndexed = true;
+                }
+
+                // If we found both, we can stop searching
+                if (hasTtl && hasIndexed) {
+                    return true;
+                }
+            }
+            currentClass = currentClass.getSuperclass();
+        }
+
+        return hasTtl && hasIndexed;
+    }
+
+    /**
+     * Clear the entity metadata cache (useful for testing or re-discovery)
+     */
+    public void clearCache() {
+        entityMetadataCache.clear();
+        log.debug("Entity metadata cache cleared");
+    }
+}

--- a/src/main/resources/application-development.yml
+++ b/src/main/resources/application-development.yml
@@ -97,6 +97,10 @@ app:
     email:
       token:
         expires-in: ${REGISTRATION_EMAIL_TOKEN_EXPIRES_IN}
+  redis:
+    cleanup:
+      enabled: ${REDIS_CLEANUP_ENABLED:true}
+      interval: ${REDIS_CLEANUP_INTERVAL:60000}
   url: ${SERVER_URL}
   frontend-url: ${FRONTEND_URL}
 

--- a/src/main/resources/application-production.yml
+++ b/src/main/resources/application-production.yml
@@ -113,6 +113,10 @@ app:
     email:
       token:
         expires-in: ${REGISTRATION_EMAIL_TOKEN_EXPIRES_IN}
+  redis:
+    cleanup:
+      enabled: ${REDIS_CLEANUP_ENABLED:true}
+      interval: ${REDIS_CLEANUP_INTERVAL:600000}
   url: ${SERVER_URL}
   frontend-url: ${FRONTEND_URL}
 

--- a/src/test/java/com/securevault/main/service/expiration/RedisCleanupSchedulerTest.java
+++ b/src/test/java/com/securevault/main/service/expiration/RedisCleanupSchedulerTest.java
@@ -1,0 +1,115 @@
+package com.securevault.main.service.expiration;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class RedisCleanupSchedulerTest {
+
+    @Mock
+    private RedisCleanupService cleanupService;
+
+    @Mock
+    private RedisEntityDiscoveryService entityDiscoveryService;
+
+    private RedisCleanupScheduler scheduler;
+
+    @BeforeEach
+    void setUp() {
+        scheduler = new RedisCleanupScheduler(cleanupService, entityDiscoveryService);
+    }
+
+    @Test
+    void testSchedulerInitialization() {
+        // Given
+        ReflectionTestUtils.setField(scheduler, "cleanupEnabled", true);
+        ReflectionTestUtils.setField(scheduler, "cleanupInterval", 60000L);
+
+        // When
+        scheduler.initialize();
+
+        // Then - This test verifies the initialize method runs without errors
+        // The actual logging behavior is tested by the fact that no exceptions are thrown
+        assertTrue(true); // If we get here, the initialization was successful
+    }
+
+    @Test
+    void testScheduledCleanupWhenEnabled() {
+        // Given
+        ReflectionTestUtils.setField(scheduler, "cleanupEnabled", true);
+        ReflectionTestUtils.setField(scheduler, "cleanupInterval", 60000L);
+        
+        RedisCleanupService.CleanupResult mockResult = new RedisCleanupService.CleanupResult();
+        when(cleanupService.performCleanup()).thenReturn(mockResult);
+
+        // When
+        scheduler.scheduledCleanup();
+
+        // Then
+        verify(cleanupService, times(1)).performCleanup();
+    }
+
+    @Test
+    void testScheduledCleanupWhenDisabled() {
+        // Given
+        ReflectionTestUtils.setField(scheduler, "cleanupEnabled", false);
+        ReflectionTestUtils.setField(scheduler, "cleanupInterval", 60000L);
+
+        // When
+        scheduler.scheduledCleanup();
+
+        // Then
+        verify(cleanupService, never()).performCleanup();
+    }
+
+    @Test
+    void testClearDiscoveryCache() {
+        // When
+        scheduler.clearDiscoveryCache();
+
+        // Then
+        verify(entityDiscoveryService, times(1)).clearCache();
+    }
+
+    @Test
+    void testScheduledCleanupWithErrors() {
+        // Given
+        ReflectionTestUtils.setField(scheduler, "cleanupEnabled", true);
+        ReflectionTestUtils.setField(scheduler, "cleanupInterval", 60000L);
+        
+        RedisCleanupService.CleanupResult mockResult = new RedisCleanupService.CleanupResult();
+        mockResult.incrementErrors();
+        when(cleanupService.performCleanup()).thenReturn(mockResult);
+
+        // When
+        scheduler.scheduledCleanup();
+
+        // Then
+        verify(cleanupService, times(1)).performCleanup();
+    }
+
+    @Test
+    void testScheduledCleanupWithCleanupResults() {
+        // Given
+        ReflectionTestUtils.setField(scheduler, "cleanupEnabled", true);
+        ReflectionTestUtils.setField(scheduler, "cleanupInterval", 60000L);
+        
+        RedisCleanupService.CleanupResult mockResult = new RedisCleanupService.CleanupResult();
+        mockResult.incrementEntitiesProcessed();
+        mockResult.addCleanedEntries(5);
+        when(cleanupService.performCleanup()).thenReturn(mockResult);
+
+        // When
+        scheduler.scheduledCleanup();
+
+        // Then
+        verify(cleanupService, times(1)).performCleanup();
+    }
+} 

--- a/src/test/java/com/securevault/main/service/expiration/RedisCleanupServiceTest.java
+++ b/src/test/java/com/securevault/main/service/expiration/RedisCleanupServiceTest.java
@@ -1,0 +1,136 @@
+package com.securevault.main.service.expiration;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationContext;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.SetOperations;
+
+import com.securevault.main.entity.JwtToken;
+
+@ExtendWith(MockitoExtension.class)
+class RedisCleanupServiceTest {
+
+    @Mock
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @Mock
+    private ApplicationContext applicationContext;
+
+    @Mock
+    private SetOperations<String, Object> setOperations;
+
+    @Mock
+    private RedisEntityDiscoveryService entityDiscoveryService;
+
+    private RedisCleanupService cleanupService;
+
+    @BeforeEach
+    void setUp() {
+        cleanupService = new RedisCleanupService(redisTemplate, entityDiscoveryService);
+        when(redisTemplate.opsForSet()).thenReturn(setOperations);
+    }
+
+    @Test
+    void testPerformCleanup() {
+        // Given
+        when(applicationContext.getBeanDefinitionNames()).thenReturn(new String[]{"jwtToken"});
+        when(applicationContext.getType("jwtToken")).thenReturn(null);
+        when(redisTemplate.keys("jwt_tokens:*")).thenReturn(Set.of("jwt_tokens:test-id"));
+        when(redisTemplate.getExpire("jwt_tokens:test-id")).thenReturn(0L); // Expired
+        when(redisTemplate.keys("jwt_tokens:userId:*")).thenReturn(Set.of("jwt_tokens:userId:123"));
+        when(setOperations.remove(anyString(), anyString())).thenReturn(1L);
+
+        // When
+        RedisCleanupService.CleanupResult result = cleanupService.performCleanup();
+
+        // Then
+        assertNotNull(result);
+        assertEquals(0, result.getEntitiesProcessed());
+        assertEquals(0, result.getIndexEntriesCleaned());
+        assertEquals(0, result.getErrors());
+    }
+
+    @Test
+    void testPerformCleanupNoExpiredTokens() {
+        // Given
+        when(applicationContext.getBeanDefinitionNames()).thenReturn(new String[]{"jwtToken"});
+        when(applicationContext.getType("jwtToken")).thenReturn(null);
+        when(redisTemplate.keys("jwt_tokens:*")).thenReturn(Set.of("jwt_tokens:test-id"));
+        when(redisTemplate.getExpire("jwt_tokens:test-id")).thenReturn(3600L); // Not expired
+
+        // When
+        RedisCleanupService.CleanupResult result = cleanupService.performCleanup();
+
+        // Then
+        assertNotNull(result);
+        assertEquals(0, result.getEntitiesProcessed());
+        assertEquals(0, result.getIndexEntriesCleaned());
+        assertEquals(0, result.getErrors());
+    }
+
+    @Test
+    void testPerformCleanupNoTokens() {
+        // Given
+        when(applicationContext.getBeanDefinitionNames()).thenReturn(new String[]{"jwtToken"});
+        when(applicationContext.getType("jwtToken")).thenReturn(null);
+        when(redisTemplate.keys("jwt_tokens:*")).thenReturn(Set.of());
+
+        // When
+        RedisCleanupService.CleanupResult result = cleanupService.performCleanup();
+
+        // Then
+        assertNotNull(result);
+        assertEquals(0, result.getEntitiesProcessed());
+        assertEquals(0, result.getIndexEntriesCleaned());
+        assertEquals(0, result.getErrors());
+    }
+
+    @Test
+    void testHasTtlAndIndexedFields() {
+        // Test JWT token class
+        assertTrue(RedisEntityDiscoveryService.hasTtlAndIndexedFields(JwtToken.class));
+        
+        // Test a class without annotations
+        assertFalse(RedisEntityDiscoveryService.hasTtlAndIndexedFields(String.class));
+    }
+
+    @Test
+    void testGetDiscoveredEntities() {
+        // Given
+        when(applicationContext.getBeanDefinitionNames()).thenReturn(new String[]{"jwtToken"});
+        when(applicationContext.getType("jwtToken")).thenReturn(null);
+
+        // When
+        java.util.Map<String, java.util.Map<String, Object>> entities = entityDiscoveryService.getDiscoveredEntities();
+
+        // Then
+        assertNotNull(entities);
+        assertTrue(entities.isEmpty());
+    }
+
+    @Test
+    void testCleanupResult() {
+        // Given
+        RedisCleanupService.CleanupResult result = new RedisCleanupService.CleanupResult();
+
+        // When
+        result.incrementEntitiesProcessed();
+        result.addCleanedEntries(5);
+        result.incrementErrors();
+
+        // Then
+        assertEquals(1, result.getEntitiesProcessed());
+        assertEquals(5, result.getIndexEntriesCleaned());
+        assertEquals(1, result.getErrors());
+        assertTrue(result.getDurationMs() >= 0);
+    }
+} 

--- a/src/test/java/com/securevault/main/service/expiration/RedisEntityDiscoveryServiceTest.java
+++ b/src/test/java/com/securevault/main/service/expiration/RedisEntityDiscoveryServiceTest.java
@@ -1,0 +1,112 @@
+package com.securevault.main.service.expiration;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationContext;
+
+import com.securevault.main.entity.JwtToken;
+
+@ExtendWith(MockitoExtension.class)
+class RedisEntityDiscoveryServiceTest {
+
+    @Mock
+    private ApplicationContext applicationContext;
+
+    private RedisEntityDiscoveryService discoveryService;
+
+    @BeforeEach
+    void setUp() {
+        discoveryService = new RedisEntityDiscoveryService();
+    }
+
+    @Test
+    void testDiscoverRedisEntities() {
+        // Given
+        when(applicationContext.getBeanDefinitionNames()).thenReturn(new String[] { "jwtToken" });
+        when(applicationContext.getType("jwtToken")).thenReturn(null);
+
+        // When
+        discoveryService.discoverRedisEntities();
+
+        // Then
+        Map<String, Map<String, Object>> entities = discoveryService.getDiscoveredEntities();
+        assertNotNull(entities);
+        assertTrue(entities.isEmpty());
+    }
+
+    @Test
+    void testExtractEntityMetadata() {
+        // When
+        RedisEntityDiscoveryService.EntityMetadata metadata = discoveryService.extractEntityMetadata(JwtToken.class);
+
+        // Then
+        assertNotNull(metadata);
+        assertEquals("jwt_tokens", metadata.getHashName());
+        assertTrue(metadata.hasTtl());
+        assertTrue(metadata.needsCleanup());
+        assertTrue(metadata.getIndexedFieldNames().size() > 0);
+    }
+
+    @Test
+    void testHasTtlAndIndexedFields() {
+        // Test JWT token class
+        assertTrue(RedisEntityDiscoveryService.hasTtlAndIndexedFields(JwtToken.class));
+
+        // Test a class without annotations
+        assertFalse(RedisEntityDiscoveryService.hasTtlAndIndexedFields(String.class));
+    }
+
+    @Test
+    void testGetEntitiesNeedingCleanup() {
+        // Given
+        when(applicationContext.getBeanDefinitionNames()).thenReturn(new String[] { "jwtToken" });
+        when(applicationContext.getType("jwtToken")).thenReturn(null);
+        discoveryService.discoverRedisEntities();
+
+        // When
+        Map<Class<?>, RedisEntityDiscoveryService.EntityMetadata> entitiesNeedingCleanup = discoveryService
+                .getEntitiesNeedingCleanup();
+
+        // Then
+        assertNotNull(entitiesNeedingCleanup);
+        assertEquals(0, entitiesNeedingCleanup.size());
+    }
+
+    @Test
+    void testEntityMetadata() {
+        // Given
+        RedisEntityDiscoveryService.EntityMetadata metadata = new RedisEntityDiscoveryService.EntityMetadata(
+                "test_hash",
+                java.util.Set.of("field1", "field2"),
+                true);
+
+        // Then
+        assertEquals("test_hash", metadata.getHashName());
+        assertEquals(2, metadata.getIndexedFieldNames().size());
+        assertTrue(metadata.hasTtl());
+        assertTrue(metadata.needsCleanup());
+    }
+
+    @Test
+    void testEntityMetadataNoCleanup() {
+        // Given
+        RedisEntityDiscoveryService.EntityMetadata metadata = new RedisEntityDiscoveryService.EntityMetadata(
+                "test_hash",
+                java.util.Set.of(),
+                false);
+
+        // Then
+        assertEquals("test_hash", metadata.getHashName());
+        assertTrue(metadata.getIndexedFieldNames().isEmpty());
+        assertFalse(metadata.hasTtl());
+        assertFalse(metadata.needsCleanup());
+    }
+}


### PR DESCRIPTION
This pull request introduces significant enhancements to the application, focusing on Redis cleanup functionality, scheduling, and build process improvements. The most notable changes include the addition of a scheduled Redis cleanup mechanism, updates to the Maven build process, and improvements to the application's logging and scheduling capabilities.

### Redis Cleanup Functionality
* Added `RedisCleanupScheduler` to handle periodic cleanup of stale Redis indexed fields, configurable via application properties (`src/main/java/com/securevault/main/service/expiration/RedisCleanupScheduler.java`).
* Implemented `RedisCleanupService` to perform the actual cleanup of Redis entities and indexed fields, with comprehensive logging and error handling (`src/main/java/com/securevault/main/service/expiration/RedisCleanupService.java`).

### Application Enhancements
* Enabled scheduling and added logging capabilities in `MainApplication` by introducing `@EnableScheduling` and `@Slf4j` annotations. A startup log message was also added to indicate application initialization (`src/main/java/com/securevault/main/MainApplication.java`).

### Build Process Improvements
* Updated the Maven command in `Dockerfile.dev` to include the `-B` flag for batch mode, ensuring cleaner logs during dependency downloads and packaging (`Dockerfile.dev`).
* Enhanced the Maven build configuration in `pom.xml` by specifying a version for `spring-boot-maven-plugin` and adding a `repackage` goal to streamline the build process (`pom.xml`).

Resolves #16 